### PR TITLE
fix(android): make onInit resilient to slow/broken TTS engines (ANR + OOM)

### DIFF
--- a/android/src/main/java/com/speech/RNSpeechModule.kt
+++ b/android/src/main/java/com/speech/RNSpeechModule.kt
@@ -60,7 +60,7 @@ class RNSpeechModule(reactContext: ReactApplicationContext) :
   private lateinit var synthesizer: TextToSpeech
 
   private var selectedEngine: String? = null
-  private var cachedEngines: List<TextToSpeech.EngineInfo>? = null
+  @Volatile private var cachedEngines: List<TextToSpeech.EngineInfo>? = null
 
   @Volatile private var isInitialized = false
   @Volatile private var isInitializing = false
@@ -260,12 +260,6 @@ class RNSpeechModule(reactContext: ReactApplicationContext) :
           synthesizer = TextToSpeech(reactApplicationContext, { status ->
             clearInitTimeout()
             if (status == TextToSpeech.SUCCESS) {
-              synchronized(initLock) {
-                isInitialized = true
-                isInitializing = false
-                initRetryCount = 0
-              }
-              cachedEngines = try { synthesizer.engines } catch (e: Exception) { null }
               synthesizer.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
                 override fun onStart(utteranceId: String) {
                   synchronized(queueLock) {
@@ -338,8 +332,24 @@ class RNSpeechModule(reactContext: ReactApplicationContext) :
                   }
                 }
               })
-              applyGlobalOptions()
-              processPendingOperations()
+              // onInit runs on the main thread; the engine/voice enumeration
+              // below ANRs on low-end devices, so run it off-thread. Apply config before
+              // flipping the flag, and keep initLock to the flag flip only — holding it
+              // across a TextToSpeech call deadlocks (upstream #11).
+              Thread {
+                // a raw Thread crashes the app on an uncaught Throwable (e.g.
+                // a getVoices() OOM on a broken engine) — backstop the body.
+                try {
+                  cachedEngines = try { synthesizer.engines } catch (e: Throwable) { null }
+                  applyGlobalOptionsInternal()
+                  synchronized(initLock) {
+                    isInitialized = true
+                    isInitializing = false
+                    initRetryCount = 0
+                  }
+                  processPendingOperations()
+                } catch (t: Throwable) {}
+              }.start()
             } else {
               onInitFailure()
             }
@@ -383,6 +393,12 @@ class RNSpeechModule(reactContext: ReactApplicationContext) :
 
   private fun applyGlobalOptions() {
     if (!isInitialized) return
+    applyGlobalOptionsInternal()
+  }
+
+  // applyGlobalOptions() without the isInitialized guard, so the init worker can apply
+  // config before the barrier opens. Don't call under initLock — it touches TextToSpeech (#11).
+  private fun applyGlobalOptionsInternal() {
     try {
       globalOptions["language"]?.let {
         synthesizer.setLanguage(Locale.forLanguageTag(it as String))
@@ -396,7 +412,8 @@ class RNSpeechModule(reactContext: ReactApplicationContext) :
       globalOptions["voice"]?.let { voiceId ->
         synthesizer.voices?.find { it.name == voiceId }?.let { synthesizer.voice = it }
       }
-    } catch (e: Exception) {}
+      // Throwable, not Exception — getVoices() can OutOfMemoryError on some engines.
+    } catch (e: Throwable) {}
   }
 
   private fun applyOptions(options: Map<String, Any>) {
@@ -409,7 +426,8 @@ class RNSpeechModule(reactContext: ReactApplicationContext) :
       temp["voice"]?.let { voiceId ->
         synthesizer.voices?.find { it.name == voiceId }?.let { synthesizer.voice = it }
       }
-    } catch (e: Exception) {}
+      // Throwable, not Exception — getVoices() can OutOfMemoryError on some engines.
+    } catch (e: Throwable) {}
   }
 
   private fun getValidatedOptions(options: ReadableMap): Map<String, Any> {
@@ -605,11 +623,13 @@ class RNSpeechModule(reactContext: ReactApplicationContext) :
     ensureInitialized(promise) {
       val enginesArray = Arguments.createArray()
       val engines = cachedEngines ?: try { synthesizer.engines } catch (e: Exception) { null }
+      // resolve defaultEngine once (a Binder IPC) instead of once per engine.
+      val defaultEngine = try { synthesizer.defaultEngine } catch (e: Exception) { "" }
       engines?.forEach { engine ->
         enginesArray.pushMap(Arguments.createMap().apply {
           putString("name", engine.name)
           putString("label", engine.label)
-          putBoolean("isDefault", engine.name == try { synthesizer.defaultEngine } catch (e: Exception) { "" })
+          putBoolean("isDefault", engine.name == defaultEngine)
         })
       }
       promise.resolve(enginesArray)


### PR DESCRIPTION
> Related to #11 / #12: this keeps `initLock` off the `TextToSpeech` call path, so it doesn't reintroduce that ABBA deadlock. It fixes a *different* pair of crashes (a main-thread-enumeration ANR and a `getVoices()` OOM), so it's complementary — happy to rebase onto #12 if that lands first.

## Problem

Two crashes on low-end Android share one root cause — the `onInit` SUCCESS branch enumerates voices/engines synchronously on the main thread:

1. **ANR** — main thread stuck *executing* `synthesizer.voices` / `synthesizer.engines` (not lock-waiting; distinct from #11's deadlock). Observed on a 4 GB, Android 15 device.
2. **OOM crash** — uncaught `OutOfMemoryError` from `TextToSpeech.getVoices()` on some cheap engines (seen on MediaTek/UMIDIGI Android 12).

## Root cause

Android delivers the `TextToSpeech` `OnInitListener` on the **main thread** (`SetupConnectionAsyncTask.onPostExecute`). The SUCCESS branch then runs, synchronously on that thread:

- `synthesizer.engines`
- `applyGlobalOptions()` → `synthesizer.voices` (when a voice is configured)
- `processPendingOperations()`, which drains queued `getAvailableVoices` / `getEngines` / `configure`

These are **synchronous Binder IPC round-trips to the engine process**.

- **ANR:** on a cold engine under memory pressure these take seconds; back-to-back on the UI thread they cross the 5 s ANR threshold.
- **OOM:** `setLanguage()` / `voices` both hit `getVoices()`. Some engines return a pathological serialized `Voice[]` that `OutOfMemoryError`s while deserializing — a runaway allocation, not memory pressure (seen with ~2.9 GB free). The existing `catch (e: Exception)` doesn't catch it (OOM is an `Error`, not an `Exception`), so it escaped uncaught and crashed the app.

## Fix

- **Off the main thread.** Run the enumeration + global-config + queue drain on a background thread. Config is applied *before* `isInitialized` flips, so a caller can't `speak` before config is applied. `initLock` guards **only** the flag flip — `applyGlobalOptions()` and the drain run lock-free, because holding `initLock` across a `TextToSpeech` call is the ABBA deadlock from #11. `cachedEngines` becomes `@Volatile`.
- **Catch the OOM.** Widen `catch (e: Exception)` → `catch (e: Throwable)` in `applyGlobalOptions()` and `applyOptions()` (the two `getVoices()`-triggering methods), and backstop the background thread with `try/catch (Throwable)` — an uncaught throwable on a raw `Thread` still kills the app.
- Also resolve `synthesizer.defaultEngine` once in `getEngines()` instead of once per engine in the loop (one Binder IPC instead of N).

## Testing

- `:compileReleaseKotlin` → BUILD SUCCESSFUL.
- The OOM guard is native Kotlin, not reachable from a JS test suite — it's validated by `compileReleaseKotlin` plus the reasoning above (OOM is a `Throwable` but not an `Exception`; widening the catch + the thread backstop close the uncaught path). I can't deterministically reproduce either crash (both sampled and device-specific), but the change removes all synchronous cross-process IPC from the UI thread, applies config before opening the barrier, keeps `initLock` off the TTS call path, and converts a `getVoices()` OOM from an app kill into a silent degrade.
